### PR TITLE
Source inclusion works when no signing supplied

### DIFF
--- a/routes/project.ts
+++ b/routes/project.ts
@@ -363,11 +363,11 @@ async function zipAppPackage(appPackage: GeneratedAppPackage, apkOptions: Androi
         if (appPackage.appBundleFilePath) {
           archive.file(appPackage.appBundleFilePath, { name: `${apkOptions.name}.aab` })
         }
+      }
 
-        // Add the source code directory if need be.
-        if (apkOptions.includeSourceCode) {
-          archive.directory(appPackage.projectDirectory, "source");
-        }
+      // Add the source code directory if need be.
+      if (apkOptions.includeSourceCode) {
+        archive.directory(appPackage.projectDirectory, "source");
       }
 
       archive.finalize();


### PR DESCRIPTION
Fixes 
- https://github.com/pwa-builder/PWABuilder/issues/1487
- https://github.com/pwa-builder/PWABuilder/issues/1569

Where source code isn't included in the zip file when the user packages with no signing options.